### PR TITLE
Feat/remove from whitelist

### DIFF
--- a/contracts/Aavegotchi/facets/GotchiLendingFacet.sol
+++ b/contracts/Aavegotchi/facets/GotchiLendingFacet.sol
@@ -202,7 +202,7 @@ contract GotchiLendingFacet is Modifiers {
         address lender = lending.lender;
         require(lender != borrower, "GotchiLending: Borrower can't be lender");
         if (lending.whitelistId > 0) {
-            require(s.isWhitelisted[lending.whitelistId][borrower], "GotchiLending: Not whitelisted address");
+            require(s.isWhitelisted[lending.whitelistId][borrower] > 0, "GotchiLending: Not whitelisted address");
         }
 
         if (lending.initialCost > 0) {

--- a/contracts/Aavegotchi/facets/WhitelistFacet.sol
+++ b/contracts/Aavegotchi/facets/WhitelistFacet.sol
@@ -81,12 +81,14 @@ contract WhitelistFacet is Modifiers {
         if (s.isWhitelisted[_whitelistId][_whitelistAddress] > 0) {
             uint256 index = s.isWhitelisted[_whitelistId][_whitelistAddress] - 1;
             uint256 lastIndex = s.whitelists[_whitelistId - 1].addresses.length - 1;
-            // Swap the last element with the element to be removed
+            // Replaces the element to be removed with the last element
             s.whitelists[_whitelistId - 1].addresses[index] = s.whitelists[_whitelistId - 1].addresses[lastIndex];
-            // Remove the last element (now the one to be removed)
-            s.whitelists[_whitelistId - 1].addresses.pop();
-            // Now they aren't whitelisted
+            // Remove the last element
+            address lastElement = s.whitelists[_whitelistId - 1].addresses.pop();
+            // Update the index of the removed element
             s.isWhitelisted[_whitelistId][_whitelistAddress] = 0;
+            // Update the index of the last element that was swapped
+            s.isWhitelisted[_whitelistId][lastElement] = index + 1;
         }
     }
 }

--- a/contracts/Aavegotchi/facets/WhitelistFacet.sol
+++ b/contracts/Aavegotchi/facets/WhitelistFacet.sol
@@ -46,6 +46,7 @@ contract WhitelistFacet is Modifiers {
         require(whitelistLength > 0, "WhitelistFacet: Whitelist length should be larger than zero");
 
         _removeAddressesFromWhitelist(_whitelistId, _whitelistAddresses);
+        emit WhitelistUpdated(uint32 indexed whitelistId);
     }
 
     function getWhitelist(uint32 _whitelistId) external view returns (Whitelist memory) {

--- a/contracts/Aavegotchi/libraries/LibAppStorage.sol
+++ b/contracts/Aavegotchi/libraries/LibAppStorage.sol
@@ -287,6 +287,7 @@ struct AppStorage {
     mapping(bytes32 => mapping(uint32 => LendingListItem)) aavegotchiLenderLendingListItem; // ("listed" or "agreed") => listingId => LendingListItem
     mapping(address => mapping(bytes32 => uint32)) aavegotchiLenderLendingHead; // user address => ("listed" or "agreed") => listingId => LendingListItem
     Whitelist[] whitelists;
+    // If zero, then the user is not whitelisted for the given whitelist ID. Otherwise, this represents the position of the user in the whitelist + 1
     mapping(uint32 => mapping(address => uint256)) isWhitelisted; // whitelistId => whitelistAddress => isWhitelisted
 }
 

--- a/contracts/Aavegotchi/libraries/LibAppStorage.sol
+++ b/contracts/Aavegotchi/libraries/LibAppStorage.sol
@@ -287,7 +287,7 @@ struct AppStorage {
     mapping(bytes32 => mapping(uint32 => LendingListItem)) aavegotchiLenderLendingListItem; // ("listed" or "agreed") => listingId => LendingListItem
     mapping(address => mapping(bytes32 => uint32)) aavegotchiLenderLendingHead; // user address => ("listed" or "agreed") => listingId => LendingListItem
     Whitelist[] whitelists;
-    mapping(uint32 => mapping(address => bool)) isWhitelisted; // whitelistId => whitelistAddress => isWhitelisted
+    mapping(uint32 => mapping(address => uint256)) isWhitelisted; // whitelistId => whitelistAddress => isWhitelisted
 }
 
 library LibAppStorage {


### PR DESCRIPTION
An implementation that allows for removing addresses from a whitelist. as it stands, an entirely new whitelist needs to be made if anyone wants to remove an address from a whitelist, which may be troublesome for groups that would like to constantly update their whitelists.