### PR TITLE
added lent gotchis and balance view

### DIFF
--- a/contracts/Aavegotchi/facets/LendingGetterAndSetterFacet.sol
+++ b/contracts/Aavegotchi/facets/LendingGetterAndSetterFacet.sol
@@ -195,6 +195,14 @@ contract LendingGetterAndSetterFacet is Modifiers {
         }
     }
 
+    function getLentTokenIdsOfLender(address _lender) external view returns (uint32[] memory tokenIds_) {
+        tokenIds_ = s.lentTokenIds[_lender];
+    }
+
+    function balanceOfLentGotchis(address _lender) external view returns (uint256 balance_) {
+        balance_ = s.lentTokenIds[_lender].length;
+    }
+
     function getGotchiLendingsLength() external view returns (uint256) {
         return s.nextGotchiListingId;
     }


### PR DESCRIPTION
Currently there is no on-chain way to get lent gotchis but the mapping exists and is updated with the functions _agreeGotchiLending() & removeLentAavegotchi() in LibGotchiLending.sol.

I added 2 new views to get the currently lent gotchis of a lender and the balance.

I didn't add any test or edge cases as they are views of an existing and used mapping.